### PR TITLE
Change self-collision behaviour to be consistent with edge-collision.

### DIFF
--- a/main.py
+++ b/main.py
@@ -115,7 +115,7 @@ class Snake:
             #check if snake collides with itself
             for x in range(1, len(self.body)):
                 if self.body[x] == self.head:
-                    self.reset()
+                    self.dead = True  # Use this instead of self.reset to trigger the nice death animation
                     break
             # to detect when the snake leaves the screen
             if not isRectInRect(vec(-1, -1), vec(root.winfo_screenwidth(), root.winfo_screenheight()),


### PR DESCRIPTION
Previously, when you collided with yourself, it would call self.reset() instantly, which would cause the snake to reset to the starting position but would not play the death animation or destroy the old body.
This PR changes it to set self.dead to True, same as how it is done when colliding with screen borders. This causes it to play the death animation and properly reset the snake (same as it does when you hit the screen borders).